### PR TITLE
Dependency paths with multiple periods should resolve.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ module.exports = function(dep, filename, directory) {
 
   if (!depExt) {
     filepath += fileExt;
+  } else {
+    // If dep has multiple periods in the name add .js explicitly
+    if (fileExt === '.js') {
+      filepath += fileExt;
+    }
   }
 
   return filepath;

--- a/index.js
+++ b/index.js
@@ -30,6 +30,11 @@ module.exports = function(dep, filename, directory) {
     // in .js AND doesn't use a custom plugin, add .js back to path.
     if (fileExt === '.js' && !dep.endsWith('.js') && dep.indexOf('!') < 0) {
       filepath += fileExt;
+    } else {
+      // If using a SystemJS style plugin
+      if (depExt.indexOf('!') > -1) {
+        filepath += depExt.substring(0, depExt.indexOf('!'));
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var path = require('path');
+require('string.prototype.endswith');
 
 /**
  * Resolve a dependency's path
@@ -25,8 +26,9 @@ module.exports = function(dep, filename, directory) {
   if (!depExt) {
     filepath += fileExt;
   } else {
-    // If dep has multiple periods in the name add .js explicitly
-    if (fileExt === '.js') {
+    // If a dependency starts with a period AND it doesn't already end
+    // in .js AND doesn't use a custom plugin, add .js back to path.
+    if (fileExt === '.js' && !dep.endsWith('.js') && dep.indexOf('!') < 0) {
       filepath += fileExt;
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/mrjoelkemp/node-resolve-dependency-path/issues"
   },
   "homepage": "https://github.com/mrjoelkemp/node-resolve-dependency-path",
+  "dependencies": {
+    "string.prototype.endswith": "^0.2.0"
+  },
   "devDependencies": {
     "jscs": "~1.8.0",
     "mocha": "~2.0.1"

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var resolvePath = require('../');
+var path = require('path');
 
 describe('resolve-dependency-path', function() {
   it('resolves with absolute paths', function() {
@@ -7,17 +8,40 @@ describe('resolve-dependency-path', function() {
     assert(resolved.indexOf(__dirname) === 0);
   });
 
-  it('resolves with multiple periods in the dependency path', function() {
-    var depPath = './bar.baz.qux';
+  it('resolves w/initial period, w/ending in .js', function() {
+    var depPath = './index';
     var filename = __dirname + '/foo.js';
     var directory = __dirname;
     var resolved = resolvePath(depPath, filename, directory);
-    assert(resolved === __dirname + '/bar.baz.qux.js');
+    assert(resolved === __dirname + '/index.js');
+  });
+
+  it('resolves w/initial period, w/o ending in .js', function() {
+    var depPath = './index.js';
+    var filename = __dirname + '/foo.js';
+    var directory = __dirname;
+    var resolved = resolvePath(depPath, filename, directory);
+    assert(resolved === __dirname + '/index.js');
+  });
+
+  it('resolves w/o initial period, w/o ending in .js', function() {
+    var depPath = 'index';
+    var filename = __dirname + '/foo.js';
+    var directory = __dirname;
+    var resolved = resolvePath(depPath, filename, directory);
+    assert(resolved === __dirname + '/index.js');
+  });
+
+  it('resolves w/o initial period, w/ending in .js', function() {
+    var depPath = 'index.js';
+    var filename = __dirname + '/foo.js';
+    var directory = __dirname;
+    var resolved = resolvePath(depPath, filename, directory);
+    assert(resolved === __dirname + '/index.js');
   });
 
   it('resolves relative paths', function() {
     var resolved = resolvePath('./bar', __dirname + '/foo.js', __dirname);
-
     assert(resolved === __dirname + '/bar.js');
   });
 
@@ -42,6 +66,42 @@ describe('resolve-dependency-path', function() {
   it('throws if the directory is missing', function() {
     assert.throws(function() {
       resolvePath('./bar', __dirname + '/foo.js');
+    });
+  });
+
+  describe('multiple period filenames', function() {
+    it('resolves with multiple periods in the dependency path', function() {
+      var depPath = './bar.baz.qux';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert(resolved === __dirname + '/bar.baz.qux.js');
+    });
+
+    it('does not duplicate extensions', function() {
+      var depPath = '../index.js';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      // Extension after removing the .js extension
+      var remainingExt = path.extname(path.basename(resolved, '.js'));
+      assert.equal(remainingExt, '');
+    });
+
+    it('does not add the incorrect extension for sass files', function() {
+      var depPath = 'styles';
+      var filename = __dirname + '/foo.scss';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert.equal(path.extname(resolved), '.scss');
+    });
+
+    it('does not add the incorrect extension for mustache files', function() {
+      var depPath = 'hgn!templates/foo.mustache';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert.equal(path.extname(resolved), '.mustache');
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,14 @@ describe('resolve-dependency-path', function() {
     assert(resolved.indexOf(__dirname) === 0);
   });
 
+  it('resolves with multiple periods in the dependency path', function() {
+    var depPath = './bar.baz.qux';
+    var filename = __dirname + '/foo.js';
+    var directory = __dirname;
+    var resolved = resolvePath(depPath, filename, directory);
+    assert(resolved === __dirname + '/bar.baz.qux.js');
+  });
+
   it('resolves relative paths', function() {
     var resolved = resolvePath('./bar', __dirname + '/foo.js', __dirname);
 

--- a/test/test.js
+++ b/test/test.js
@@ -104,4 +104,36 @@ describe('resolve-dependency-path', function() {
       assert.equal(path.extname(resolved), '.mustache');
     });
   });
+  describe('implicit jspm/systemjs style plugins', function() {
+    it('resolve w/initial period', function() {
+      var depPath = './templates/file.css!';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert.equal(path.extname(resolved), '.css');
+    });
+    it('resolve w/o initial period', function() {
+      var depPath = 'templates/file.css!';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert.equal(path.extname(resolved), '.css');
+    });
+  });
+  describe('explicit jspm/systemjs style plugins', function() {
+    it('resolve w/initial period', function() {
+      var depPath = './templates/file.txt!text';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert.equal(path.extname(resolved), '.txt');
+    });
+    it('resolve w/o initial period', function() {
+      var depPath = 'templates/file.txt!text';
+      var filename = __dirname + '/foo.js';
+      var directory = __dirname;
+      var resolved = resolvePath(depPath, filename, directory);
+      assert.equal(path.extname(resolved), '.txt');
+    });
+  });
 });


### PR DESCRIPTION
Adds the .js extension back in the case of dependency paths with multiple periods in them.
Adds associated test.
